### PR TITLE
adds vso.release_execute scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,35 @@
-Ghost Inspector Extension for Azure DevOps
--------------
+## Ghost Inspector Extension for Azure DevOps
 
 Build status: ![build status](https://circleci.com/gh/ghost-inspector/ghost-inspector-azure-devops.svg?style=shield&circle-token=05c5ca3ba409f6a6766a455a2aae6811b822003e)
 
 With this plugin you can add a build step to your Azure DevOps project that executes a Ghost Inspector test suite. If the test suite is successful, your pipeline will continue to the next step in your pipeline; however, if it fails (or times out), the build will be marked as failed.
 
 ## Installation
+
 This plugin can be installed from within the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=ghost-inspector.ghost-inspector-vsts-extension).
 
 ## Prerequisites
-* **API Key** - This is a unique, private key provided with your account which allows you to access the API. You can find it in your Ghost Inspector account settings at https://app.ghostinspector.com/account.
-* **Suite ID** - The ID of the Ghost Inspector suite that you would like to execute.
- 
+
+- **API Key** - This is a unique, private key provided with your account which allows you to access the API. You can find it in your Ghost Inspector account settings at https://app.ghostinspector.com/account.
+- **Suite ID** - The ID of the Ghost Inspector suite that you would like to execute.
+
 ## Usage
+
 1. Install the extension from [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=ghost-inspector.ghost-inspector-vsts-extension).
 1. Open your project within Azure DevOps and navigate to **Builds**.
-2. In the **Tasks** section, click the ```+``` icon to add a new task.
-3. To find the extension in the list quickly, type `Ghost` in the search box and select **Add**.
-4. Click on the new task and fill in the required fields for **Suite ID** and **API Key**.
-4. If you would like to run your Ghost Inspector tests on a URL other than their default setting (such as a local build instance of your application using a tunnel), enter the start URL in the **Start URL** field.
-5. If you would like to pass other [custom parameters](https://ghostinspector.com/docs/api/suites/#execute) or [variables](https://ghostinspector.com/docs/variables/) to your suite run, specify them in the **Additional Parameters** field using JSON (eg: `{"browser":"chrome", "myVar":"some value"}`).
-6. Save and queue your project.
+1. In the **Tasks** section, click the `+` icon to add a new task.
+1. To find the extension in the list quickly, type `Ghost` in the search box and select **Add**.
+1. Click on the new task and fill in the required fields for **Suite ID** and **API Key**.
+1. If you would like to run your Ghost Inspector tests on a URL other than their default setting (such as a local build instance of your application using a tunnel), enter the start URL in the **Start URL** field.
+1. If you would like to pass other [custom parameters](https://ghostinspector.com/docs/api/suites/#execute) or [variables](https://ghostinspector.com/docs/variables/) to your suite run, specify them in the **Additional Parameters** field using JSON (eg: `{"browser":"chrome", "myVar":"some value"}`).
+1. Save and queue your project.
 
 # Development
+
 The extension is written in TypeScript. Between changes, you can run the tests with `npm test` in the `run-suite-task` directory.
 
 # Building the extension
+
 Make sure you have transpiled the latest TypeScript to JavaScript in the `run-suite-task` directory:
 
 ```
@@ -40,12 +44,12 @@ $ npm install -g tfx-cli
 
 You will need to increment the appropriate version number before you can build and publish this extension:
 
- * [vss-extension.json](./vss-extension.json)
- * [run-suite-task/package.json](run-suite-task/package.json)
- * [run-suite-task/task.json](run-suite-task/task.json)
-
+- [vss-extension.json](./vss-extension.json)
+- [run-suite-task/package.json](run-suite-task/package.json)
+- [run-suite-task/task.json](run-suite-task/task.json)
 
 Create the extension with this command:
+
 ```
 $ tfx extension create
 ```
@@ -54,20 +58,23 @@ The extension should now be in the project root under `ghost-inspector.ghost-ins
 
 ## Publishing to Azure Devops Marketplace
 
-First you will need to sign into Azure Devops Marketplace, then navigate to *Publish Extensions*. Click on *Update* in the dropdown beside the Ghost Inspector plugin version, and drag the new `.vsix` file onto the upload area and click *Upload*.
+First you will need to sign into Azure Devops Marketplace, then navigate to _Publish Extensions_. Click on _Update_ in the dropdown beside the Ghost Inspector plugin version, and drag the new `.vsix` file onto the upload area and click _Upload_.
 
 ## Issues
+
 Please report any issues [on Github](https://github.com/ghost-inspector/ghost-inspector-azure-devops/issues) or [through our support channel](https://ghostinspector.com/support/).
 
 ## Change Log
- - 2020-04-06 - `1.0.11`: Rebundles package, `1.0.10` was missing `*.js` files and would not execute.
- - 2020-04-06 - `1.0.10`: Depdendency updates
- - 2020-01-28 - `1.0.9`: Rebundles package, `1.0.8` was missing `*.js` files and would not execute.
- - 2020-01-27 - `1.0.8`: Updates references in docs from "VSTS" to "Azure DevOps"
- - 2019-09-19 - `1.0.7`: Obscure exposed API key in suite execute call, update dependencies
- - 2019-05-01 - `1.0.6`: Updates `axios` to address vulnerability
- - 2018-07-18 - `1.0.5`: Add compatibility for TFS2017 (node `v5.x`/`ES5`)
- - 2018-04-03 - `1.0.4`: Fix `parameters` typo
- - 2018-03-15 - `1.0.2`: Add CI config and public build status
- - 2018-03-13 - `1.0.1`: Patch to fix not passing startUrl
- - 2018-02-26 - `1.0.0`: Initial release
+
+- 2020-04-21 - `1.0.12`: Adds `vso.release_execute` scope.
+- 2020-04-06 - `1.0.11`: Rebundles package, `1.0.10` was missing `*.js` files and would not execute.
+- 2020-04-06 - `1.0.10`: Depdendency updates
+- 2020-01-28 - `1.0.9`: Rebundles package, `1.0.8` was missing `*.js` files and would not execute.
+- 2020-01-27 - `1.0.8`: Updates references in docs from "VSTS" to "Azure DevOps"
+- 2019-09-19 - `1.0.7`: Obscure exposed API key in suite execute call, update dependencies
+- 2019-05-01 - `1.0.6`: Updates `axios` to address vulnerability
+- 2018-07-18 - `1.0.5`: Add compatibility for TFS2017 (node `v5.x`/`ES5`)
+- 2018-04-03 - `1.0.4`: Fix `parameters` typo
+- 2018-03-15 - `1.0.2`: Add CI config and public build status
+- 2018-03-13 - `1.0.1`: Patch to fix not passing startUrl
+- 2018-02-26 - `1.0.0`: Initial release

--- a/run-suite-task/package.json
+++ b/run-suite-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-inspector-vsts-task-extension",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Trigger your Ghost Inspector test suite in your Azure DevOps build.",
   "main": "index.js",
   "repository": {

--- a/run-suite-task/task.json
+++ b/run-suite-task/task.json
@@ -7,57 +7,57 @@
   "category": "Test",
   "author": "Ghost Inspector",
   "version": {
-      "Major": 1,
-      "Minor": 0,
-      "Patch": 11
+    "Major": 1,
+    "Minor": 0,
+    "Patch": 12
   },
   "instanceNameFormat": "Execute Suite $(suiteid)",
   "groups": [
-      {
-          "name": "advanced",
-          "displayName": "Advanced",
-          "isExpanded": false
-      }
+    {
+      "name": "advanced",
+      "displayName": "Advanced",
+      "isExpanded": false
+    }
   ],
   "inputs": [
-      {
-          "name": "suiteid",
-          "type": "string",
-          "label": "Suite ID",
-          "defaultValue": "",
-          "required": true,
-          "helpMarkDown": "The ID of your Ghost Inspector Suite to execute."
-      },
-      {
-          "name": "apikey",
-          "type": "string",
-          "label": "API Key",
-          "defaultValue": "",
-          "required": true,
-          "helpMarkDown": "Your Ghost Inspector API key, [available in your account](https://app.ghostinspector.com/account)."
-      },
-      {
-          "name": "starturl",
-          "type": "string",
-          "label": "Start URL",
-          "defaultValue": "",
-          "required": false,
-          "helpMarkDown": "Alternative start URL for your test suite ([documentation](https://ghostinspector.com/docs/reusing-tests-different-environments/#overriding)).",
-          "groupName": "advanced"
-      },
-      {
-          "name": "parameters",
-          "type": "string",
-          "label": "Additional Parameters (JSON)",
-          "defaultValue": "",
-          "required": false,
-          "helpMarkDown": "[Additional parameters](https://ghostinspector.com/docs/api/suites/#execute) or [custom variables](https://ghostinspector.com/docs/variables/) in JSON format to POST to the API).",
-          "groupName": "advanced"
-      }
+    {
+      "name": "suiteid",
+      "type": "string",
+      "label": "Suite ID",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "The ID of your Ghost Inspector Suite to execute."
+    },
+    {
+      "name": "apikey",
+      "type": "string",
+      "label": "API Key",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Your Ghost Inspector API key, [available in your account](https://app.ghostinspector.com/account)."
+    },
+    {
+      "name": "starturl",
+      "type": "string",
+      "label": "Start URL",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Alternative start URL for your test suite ([documentation](https://ghostinspector.com/docs/reusing-tests-different-environments/#overriding)).",
+      "groupName": "advanced"
+    },
+    {
+      "name": "parameters",
+      "type": "string",
+      "label": "Additional Parameters (JSON)",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "[Additional parameters](https://ghostinspector.com/docs/api/suites/#execute) or [custom variables](https://ghostinspector.com/docs/variables/) in JSON format to POST to the API).",
+      "groupName": "advanced"
+    }
   ],
   "execution": {
-      "Node": {
-          "target": "index.js"
-      }
+    "Node": {
+      "target": "index.js"
+    }
   }
 }

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "id": "ghost-inspector-vsts-extension",
   "publisher": "ghost-inspector",
   "name": "Ghost Inspector Integration",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Ghost Inspector is an automated browser UI testing and monitoring tool. This integration allows you to execute your Ghost Inspector test suites directly within your Azure DevOps build.",
   "tags": [
     "Automated Testing",
@@ -30,12 +30,8 @@
       "id": "Microsoft.VisualStudio.Services"
     }
   ],
-  "scopes": [
-    "vso.build_execute"
-  ],
-  "categories": [
-    "Build and release"
-  ],
+  "scopes": ["vso.build_execute", "vso.release_execute"],
+  "categories": ["Build and release"],
   "content": {
     "details": {
       "path": "overview.md"
@@ -49,7 +45,7 @@
       "uri": "https://www.ghostinspector.com/"
     },
     "getstarted": {
-        "uri": "https://ghostinspector.com/docs/getting-started/"
+      "uri": "https://ghostinspector.com/docs/getting-started/"
     },
     "repository": {
       "uri": "https://github.com/ghost-inspector/ghost-inspector-azure-devops"
@@ -68,7 +64,8 @@
   "files": [
     {
       "path": "run-suite-task"
-    }, {
+    },
+    {
       "path": "icon.png",
       "addressable": true
     }
@@ -77,9 +74,7 @@
     {
       "id": "package-extension-build-task",
       "type": "ms.vss-distributed-task.task",
-      "targets": [
-        "ms.vss-distributed-task.tasks"
-      ],
+      "targets": ["ms.vss-distributed-task.tasks"],
       "properties": {
         "name": "run-suite-task"
       }


### PR DESCRIPTION
This should solve a customer request, currently the plugin is only scoped to `build` tasks, this should allow for `release` tasks as well.